### PR TITLE
Fix download metro extracts Failed to validate the SSL certificate error.

### DIFF
--- a/ansible/import-data.yml
+++ b/ansible/import-data.yml
@@ -5,7 +5,7 @@
     sudo: no
 
   - name: download metro extracts
-    get_url: url=https://s3.amazonaws.com/metro-extracts.mapzen.com/{{item}}.osm.pbf dest={{metro_tmp_dir}}/{{item}}.osm.pbf
+    get_url: url=http://s3.amazonaws.com/metro-extracts.mapzen.com/{{item}}.osm.pbf dest={{metro_tmp_dir}}/{{item}}.osm.pbf
     with_items: metro_extracts
     when: metro_extracts
     sudo: no


### PR DESCRIPTION
This worked for me after changing the url.

```
==> default: TASK: [download metro extracts] ***********************************************
==> default: failed: [default] => (item=detroit_michigan) => {"failed": true, "item": "detroit_michigan"}
==> default: msg: Failed to validate the SSL certificate for s3.amazonaws.com:443. Use     validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths     checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-  certificates/cacert.org, /etc/ansible
==> default:
==> default: FATAL: all hosts have already failed -- aborting
```
